### PR TITLE
improvements and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist
 
 # Ignore if testing config file
 mockidp.yaml
+
+# virtual environment
+venv

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "debug-mock-idp",
+            "type": "python",
+            "request": "launch",
+            "program": "run-mock-idp.py",
+            "console": "integratedTerminal",
+            "args": [
+                "-d"
+            ]
+        },
+    ]
+}

--- a/mockidp/main.py
+++ b/mockidp/main.py
@@ -28,4 +28,4 @@ def main(argv):
         print(f"Loaded user {username}")
 
     sys.stdout.flush()
-    app.run(debug=options.debug, host="0.0.0.0", port=options.port)
+    app.run(debug=options.debug, host="127.0.0.1", port=options.port)

--- a/mockidp/resources/default_config.yaml
+++ b/mockidp/resources/default_config.yaml
@@ -1,6 +1,7 @@
 service_providers:
   - name: "local:aem:author"
     response_url: "http://localhost:14502/saml_login"
+    logout_url: "http://localhost:14502/saml_logout"
 
 users:
   charlie:

--- a/mockidp/saml/response.py
+++ b/mockidp/saml/response.py
@@ -34,7 +34,7 @@ def sign_assertions(response_str):
     key = read_bytes("keys/key.pem")
     for e in response_element.findall('{urn:oasis:names:tc:SAML:2.0:assertion}Assertion'):
         signer = XMLSigner(c14n_algorithm="http://www.w3.org/2001/10/xml-exc-c14n#",
-                           signature_algorithm='rsa-sha1', digest_algorithm='sha1')
+                           signature_algorithm='rsa-sha256', digest_algorithm='sha256')
         signed_e = signer.sign(e, key=key, cert=cert)
         response_element.replace(e, signed_e)
     return etree.tostring(response_element, pretty_print=True)

--- a/mockidp/templates/saml/logout_response.xml
+++ b/mockidp/templates/saml/logout_response.xml
@@ -2,7 +2,7 @@
         xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
         Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" 
         ID="{{ session.id }}" 
-        IssueInstant="{{ session.created|timestamp }}" 
+        IssueInstant="{{ issue_instant }}" 
         Destination="{{ destination }}" 
         InResponseTo="{{ session.request_id }}">
     <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">

--- a/mockidp/templates/saml_response.xml
+++ b/mockidp/templates/saml_response.xml
@@ -3,7 +3,7 @@
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-    ID="{{ session.id }}" InResponseTo="{{ session.request_id }}" IssueInstant="{{ session.created|timestamp }}"
+    ID="{{ session.id }}" InResponseTo="{{ session.request_id }}" IssueInstant="{{ issue_instant }}"
     Version="2.0">
 
     <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>
@@ -11,7 +11,7 @@
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
     </samlp:Status>
     <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-            ID="{{ session.id }}-4711" IssueInstant="{{ session.created|timestamp }}" Version="2.0">
+            ID="{{ session.id }}-4711" IssueInstant="{{ issue_instant }}" Version="2.0">
         <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>
         <ds:Signature Id="placeholder" />
         <saml:Subject>

--- a/run-mock-idp.py
+++ b/run-mock-idp.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+
+from mockidp.main import main
+
+if __name__ == '__main__':
+    try:
+        print("Launching main")
+        main(sys.argv)
+    except KeyboardInterrupt as e:
+        sys.exit(-1)
+


### PR DESCRIPTION
Thank you for this project!
I used it successfully together with this Java SP library: https://github.com/onelogin/java-saml

However, I had to adjust some minor stuff and I want to share my findings:

- added vscode launch config
    - therefor, moved file in bin-folder one level up and renamed it to "run-mock-idp.py" (see also #4 )
- set logout_url in default_config.yaml to fix exception and make it clear that this config exists
    - there was a crash in response.py in create_logout_response because 'logout_url' was not a valid key
- use sha256 for signature and digest. sha1 is deprecated and may cause issues
    - the Java SP library was complaining because of sha1
- set IssueInstant in UTC form of ISO-8601 format
    - the Java SP library was complaining because of this
- use localhost (127.0.0.1) as default host address
    - not sure why anyone would want 0.0.0.0. I never saw this. with 127.0.0.1 it is usable out-of-the-box