### PR TITLE
Fix `Conditions` element position, and response enhancements

### DIFF
--- a/mockidp/core/session.py
+++ b/mockidp/core/session.py
@@ -10,6 +10,7 @@ class Session:
         self.user = user
         self.request_id = request.id
         self.sp_entity_id = request.sp_entity_id
+        self.idp_id = request.idp_id
         self.id = _generate_session_id(user['username'])
         self.created = time.time()
 

--- a/mockidp/saml/request.py
+++ b/mockidp/saml/request.py
@@ -8,10 +8,11 @@ from lxml import etree
 
 
 class SAMLRequest:
-    def __init__(self, _id, sp_entity_id=None, name_id=None):
+    def __init__(self, _id, sp_entity_id=None, name_id=None, idp_id=None):
         self.id = _id
         self.sp_entity_id = sp_entity_id
         self.name_id = name_id
+        self.idp_id = idp_id
 
 def try_deflate(request_body):
     try:

--- a/mockidp/saml/routes.py
+++ b/mockidp/saml/routes.py
@@ -36,6 +36,7 @@ def begin_login_get():
     logging.info("Got saml_request %s", saml_request)
 
     req = parse_request(saml_request)
+    req.idp_id = flask.request.base_url
 
     logging.info("Storing request %s", req.id)
     open_saml_requests[req.id] = req

--- a/mockidp/templates/saml_response.xml
+++ b/mockidp/templates/saml_response.xml
@@ -3,7 +3,7 @@
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-    ID="{{ session.id }}" InResponseTo="{{ session.request_id }}" IssueInstant="{{ issue_instant }}"
+    ID="{{ session.id }}" InResponseTo="{{ session.request_id }}" IssueInstant="{{ issue_instant }}"
     Version="2.0">
 
     <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>

--- a/mockidp/templates/saml_response.xml
+++ b/mockidp/templates/saml_response.xml
@@ -15,7 +15,7 @@
         <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>
         <ds:Signature Id="placeholder" />
         <saml:Subject>
-            <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">{{ user.username }}</saml:NameID>
+            <saml:NameID SPNameQualifier="{{ session.sp_entity_id }}" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">{{ user.username }}</saml:NameID>
             <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
                 <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
             </saml:SubjectConfirmation>

--- a/mockidp/templates/saml_response.xml
+++ b/mockidp/templates/saml_response.xml
@@ -20,6 +20,11 @@
                 <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
             </saml:SubjectConfirmation>
         </saml:Subject>
+        <saml:Conditions>
+            <saml:AudienceRestriction>
+                <saml:Audience>{{ session.sp_entity_id }}</saml:Audience>
+            </saml:AudienceRestriction>
+        </saml:Conditions>
         <saml:AttributeStatement>
             <saml:Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
                 <saml:AttributeValue xsi:type="xs:string">{{ user.username }}</saml:AttributeValue>
@@ -39,13 +44,7 @@
                 <saml:AttributeValue xsi:type="xs:string">{{ attrib.value }}</saml:AttributeValue>
             </saml:Attribute>
             {% endfor -%}
-            
         </saml:AttributeStatement>
-        <saml:Conditions>
-            <saml:AudienceRestriction>
-                <saml:Audience>{{ session.sp_entity_id }}</saml:Audience>
-            </saml:AudienceRestriction>
-        </saml:Conditions>
         <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z"
             SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
             <saml:AuthnContext>

--- a/mockidp/templates/saml_response.xml
+++ b/mockidp/templates/saml_response.xml
@@ -6,13 +6,13 @@
     ID="{{ session.id }}" InResponseTo="{{ session.request_id }}" IssueInstant="{{ issue_instant }}"
     Version="2.0">
 
-    <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>
+    <saml:Issuer>{{ session.idp_id }}</saml:Issuer>
     <samlp:Status>
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
     </samlp:Status>
     <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"
             ID="{{ session.id }}-4711" IssueInstant="{{ issue_instant }}" Version="2.0">
-        <saml:Issuer>http://localhost:5000/metadata</saml:Issuer>
+        <saml:Issuer>{{ session.idp_id }}</saml:Issuer>
         <ds:Signature Id="placeholder" />
         <saml:Subject>
             <saml:NameID SPNameQualifier="{{ session.sp_entity_id }}" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">{{ user.username }}</saml:NameID>


### PR DESCRIPTION
Hello! First off, thanks for creating this app. I'm just getting my feet wet with SAML integration in a Ruby app and this is a handy tool.

I encountered a couple issues along the way and want to share my fixes. If they should be broken up into separate PRs, let me know.

## `Conditions` position

The SP library I'm using validates SAML responses with this XSD: https://docs.oasis-open.org/security/saml/v2.0/saml-schema-assertion-2.0.xsd. As far as I can tell, this XSD is the standard.

TIL that validating XML with XSD is sensitive to the order of elements in the document.

I ran into a validation error since `Conditions` was appearing after the `AudienceRestriction`, but according to the XSD, it should be before it.

https://www.samltool.com/validate_xml.php

## `SPNameQualifier`

The SP library I'm using by default wants the `SPNameQualifier` to match our ID. Otherwise it thinks the response is invalid.

According to [the SAML specification](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), the field is:

> Further qualifies a name with the name of a service provider or affiliation of providers. This attribute provides an additional means to federate names on the basis of the relying party or parties

So I think it makes sense that it match the service provider ID rather than be hardcoded.

## `Issuer`

This one didn't specifically cause me a problem, but I was confused to see in the response that `Issuer` was not correct for how I was running the IDP. I'm running via Docker with a different port